### PR TITLE
add posthog stats on installs, updates, and fix race condition on urls

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -137,7 +137,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 
   if (details.reason === 'update') {
     chrome.management.getSelf().then((res) => {
-      posthog.capture('update');
+      posthog.capture('update', { version: res.version });
     });
   }
 });

--- a/src/pages/phishing.tsx
+++ b/src/pages/phishing.tsx
@@ -52,6 +52,7 @@ export function PhishingWarning() {
       dsn: 'https://d6ac9c557b4c4eee8b1d4224528f52b3@o4504402373640192.ingest.sentry.io/4504402378293248',
       integrations: [new BrowserTracing()],
     });
+    posthog.capture('show phishing screen', { phishingWebsite: proceedAnywayUrl, reason });
   }, []);
 
   function openSafeLink() {
@@ -85,7 +86,6 @@ export function PhishingWarning() {
   }
 
   function getWarningText() {
-    posthog.capture('show phishing screen', { phishingWebsite: proceedAnywayUrl, reason });
     if (isConfirmedPhishing) {
       return (
         <Text variant={'muted'} fontSize={'lg'}>


### PR DESCRIPTION
Added:
- Posthog stats on installs, updates

Fixed:
- `getWarningText()` was firing before `useEffect()`, therefore posthog.capture was getting fired before it was initialized. Which is why we were not seeing events coming through. I verified that this fix fires in the correct order and posthog is now showing the events correctly.