### PR TITLE
Feature: Uninstall & dashboard metrics

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -27,7 +27,7 @@ Sentry.init({
 // Open Dashboard on Extension click
 chrome.action.onClicked.addListener(function (tab) {
   // TODO: Make this open the current popup if one exists
-  openDashboard();
+  openDashboard('toolbar');
 });
 
 // MESSAGING
@@ -77,7 +77,7 @@ chrome.management.onInstalled.addListener(async (extensionInfo) => {
       key: `extension:${extensionInfo.id}`,
     } as AlertDetail;
     AlertHandler.create(activityInfo);
-    openDashboard();
+    openDashboard('malicious_extension');
   }
 });
 
@@ -124,8 +124,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   await checkAllWalletsAndCreateAlerts();
 
   if (process.env.NODE_ENV === 'production' && details.reason === 'install') {
-    openDashboard();
-    chrome.runtime.setUninstallURL('https://forms.gle/KzGYKYFzUpYtTn9i8');
+    openDashboard('install');
   }
 });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -24,10 +24,16 @@ Sentry.init({
   dsn: 'https://d6ac9c557b4c4eee8b1d4224528f52b3@o4504402373640192.ingest.sentry.io/4504402378293248',
 });
 
-// Open Dashboard on Extension click
+// Open Dashboard or Simulation Popup on toolbar click
 chrome.action.onClicked.addListener(function (tab) {
-  // TODO: Make this open the current popup if one exists
-  openDashboard('toolbar');
+  // Open the current simulation popup if one exists
+  if (currentPopup && currentPopup !== -1) {
+    chrome.windows.update(currentPopup, {
+      focused: true,
+    });
+  } else {
+    openDashboard('toolbar');
+  }
 });
 
 // MESSAGING

--- a/src/components/app-dashboard/tabs/dashboard/DashboardTab.module.css
+++ b/src/components/app-dashboard/tabs/dashboard/DashboardTab.module.css
@@ -95,7 +95,7 @@
 .continue {
   opacity: 0;
   animation: fadeIn ease 2s forwards 1.2s;
-  animation-delay: 3s;
+  animation-delay: 2s;
 }
 
 .tutorialContainer {

--- a/src/components/app-dashboard/tabs/dashboard/subComponents/GoodStanding.tsx
+++ b/src/components/app-dashboard/tabs/dashboard/subComponents/GoodStanding.tsx
@@ -11,7 +11,7 @@ const GoodStandingComponent = () => {
       </div>
       <div className="row">
         <div className="col-12" style={{ paddingLeft: '25px' }}>
-          <p style={{ paddingTop: '3%' }}>We'll let you know if we detect anything suspicous while you're browsing.</p>
+          <p style={{ paddingTop: '3%' }}>We'll let you know if we detect anything suspicious while you're browsing.</p>
         </div>
       </div>
     </>

--- a/src/lib/helpers/linkHelper.ts
+++ b/src/lib/helpers/linkHelper.ts
@@ -1,6 +1,6 @@
 export function openGuide() {
   chrome.tabs.create({
-    url: 'https://medium.com/@walletguardofficial/how-to-update-browser-extensions-e61b1138cf7e'
+    url: 'https://www.walletguard.app/blog/how-to-update-browser-extensions'
   });
 }
 

--- a/src/lib/helpers/linkHelper.ts
+++ b/src/lib/helpers/linkHelper.ts
@@ -1,18 +1,15 @@
-import posthog from 'posthog-js'
-
 export function openGuide() {
   chrome.tabs.create({
     url: 'https://medium.com/@walletguardofficial/how-to-update-browser-extensions-e61b1138cf7e'
   });
 }
 
-export function openDashboard(updateCurrentURL = false) {
-  posthog.capture('open dashboard');
+export function openDashboard(source: string, updateCurrentURL = false) {
   if (updateCurrentURL) {
-    chrome.tabs.update({ url: 'chrome-extension://pdgbckgdncnhihllonhnjbdoighgpimk/dashboard.html' });
+    chrome.tabs.update({ url: 'chrome-extension://pdgbckgdncnhihllonhnjbdoighgpimk/dashboard.html?source=' + source });
   } else {
     chrome.tabs.create({
-      url: 'chrome-extension://pdgbckgdncnhihllonhnjbdoighgpimk/dashboard.html'
+      url: 'chrome-extension://pdgbckgdncnhihllonhnjbdoighgpimk/dashboard.html?source=' + source
     });
   }
 }

--- a/src/pages/phishing.tsx
+++ b/src/pages/phishing.tsx
@@ -172,7 +172,11 @@ export function PhishingWarning() {
               </Button>
             )}
             {safeUrl === 'null' && (
-              <Button onClick={() => openDashboard(true)} variant="primary" rightIcon={<CheckIcon />}>
+              <Button
+                onClick={() => openDashboard('phishing_page_my_dashboard', true)}
+                variant="primary"
+                rightIcon={<CheckIcon />}
+              >
                 My Dashboard
               </Button>
             )}

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -31,6 +31,10 @@ const Popup = () => {
     integrations: [new BrowserTracing()],
   });
 
+  // SET THIS TEMPORARILY TO UPDATE CURRENT USERS - Remove after 0.7.5
+  const uid = posthog.get_distinct_id();
+  chrome.runtime.setUninstallURL('https://walletguard.app/uninstall?id=' + uid);
+
   useEffect(() => {
     chrome.storage.local.get('simulations').then(({ simulations }) => {
       setStoredSimulations(simulations);


### PR DESCRIPTION
- Adds Uninstall metrics by sending user to our website
- Adds `source` as an insight into dashboard opens
- Fix: When clicking the Wallet Guard icon on the toolbar, open the current simulation popup (if one exists). Otherwise open the Dashboard
- Fix: Decreased Get Started button animation delay in onboarding from `3s` to `2s` in an attempt to increase retention