### PR TITLE
Make Set Approval For All less scary on approved websites

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -81,6 +81,7 @@ chrome.management.onInstalled.addListener(async (extensionInfo) => {
       category: AlertCategory.MaliciousExtension,
       details: `Disabled extension: ${extensionInfo.name}`,
       key: `extension:${extensionInfo.id}`,
+      data: extensionInfo,
     } as AlertDetail;
     AlertHandler.create(activityInfo);
     openDashboard('malicious_extension');

--- a/src/components/app-dashboard/tabs/dashboard/DashboardTab.tsx
+++ b/src/components/app-dashboard/tabs/dashboard/DashboardTab.tsx
@@ -24,7 +24,7 @@ import { AlertHandler } from '../../../../lib/helpers/chrome/alertHandler';
 import localStorageHelpers from '../../../../lib/helpers/chrome/localStorage';
 import { WgKeys } from '../../../../lib/helpers/chrome/localStorageKeys';
 import { Settings, WG_DEFAULT_SETTINGS } from '../../../../lib/settings';
-import { AlertDetail } from '../../../../models/Alert';
+import { AlertCategory, AlertDetail } from '../../../../models/Alert';
 import { WalletInfo } from '../../../../models/VersionChecker';
 import { checkAllWalletsAndCreateAlerts } from '../../../../services/http/versionService';
 import { Feedback } from '../../../common/Feedback';
@@ -62,6 +62,15 @@ export function DashboardTab() {
       chrome.action.getUserSettings().then((settings) => {
         setUnreadAlerts(alerts);
         posthog.capture('visit dashboard', { alertsCount: alerts.length, isPinned: settings.isOnToolbar });
+
+        const hasMaliciousExtensions = alerts.filter((alert) => alert.category === AlertCategory.MaliciousExtension);
+        for (let ext of hasMaliciousExtensions) {
+          posthog.capture('malicious extension disabled', {
+            extensionId: ext.key,
+            name: ext.details,
+            data: ext.data,
+          });
+        }
       });
     });
     localStorageHelpers.get<boolean>(WgKeys.TutorialComplete).then((res) => {

--- a/src/components/simulation/SimulationSubComponents/ChangeTypeSection.tsx
+++ b/src/components/simulation/SimulationSubComponents/ChangeTypeSection.tsx
@@ -3,11 +3,13 @@ import { SimulationStateChange } from '../../../models/simulation/Transaction';
 import { StateChangesComponent } from './StateChangesComponent';
 import styles from '../simulation.module.css';
 import { RiskFactors } from './stateChangeSubComponents/RiskFactors';
+import { PhishingResponse } from '../../../models/PhishingResponse';
 
 export interface ChangeTypeSectionProps {
   stateChanges?: SimulationStateChange[];
   title: string;
   warnings?: any;
+  scanResult: PhishingResponse;
 }
 
 export const ChangeTypeSection = (props: ChangeTypeSectionProps) => {
@@ -40,7 +42,9 @@ export const ChangeTypeSection = (props: ChangeTypeSectionProps) => {
               <div className="row">
                 <div className="col">
                   {props.warnings && <RiskFactors warnings={props.warnings} />}
-                  {props.stateChanges && <StateChangesComponent simulationStateChanges={props.stateChanges} />}
+                  {props.stateChanges && (
+                    <StateChangesComponent simulationStateChanges={props.stateChanges} scanResult={props.scanResult} />
+                  )}
                 </div>
               </div>
             </div>

--- a/src/components/simulation/SimulationSubComponents/StateChangesComponent.tsx
+++ b/src/components/simulation/SimulationSubComponents/StateChangesComponent.tsx
@@ -16,9 +16,11 @@ import {
   TransferToken,
 } from './stateChangeSubComponents/StateChangeSubComponents';
 import { TokenInfo } from './stateChangeSubComponents/TokenInfo';
+import { PhishingResponse } from '../../../models/PhishingResponse';
 
 export interface StateChangesComponentProps {
   simulationStateChanges: SimulationStateChange[];
+  scanResult: PhishingResponse;
 }
 
 export const add3Dots = (string: string, limit: number) => {
@@ -82,7 +84,7 @@ export const StateChangesComponent = (props: StateChangesComponentProps) => {
                             {isTransfer(stateChange) ? (
                               <TransferNFT stateChange={stateChange} />
                             ) : stateChange.changeType === SimulationChangeType.ChangeTypeApprovalForAll ? (
-                              <SetApprovalForAll />
+                              <SetApprovalForAll verified={props.scanResult.verified} />
                             ) : stateChange.changeType === SimulationChangeType.ChangeTypeRevokeApprovalForAll ? (
                               <RevokeApprovalForAll />
                             ) : isReceive(stateChange) ? (
@@ -96,7 +98,7 @@ export const StateChangesComponent = (props: StateChangesComponentProps) => {
                             {isTransfer(stateChange) ? (
                               <TransferToken stateChange={stateChange} />
                             ) : stateChange.changeType === SimulationChangeType.ChangeTypeApprovalForAll ? (
-                              <SetApprovalForAll />
+                              <SetApprovalForAll verified={props.scanResult.verified} />
                             ) : stateChange.changeType === SimulationChangeType.ChangeTypeRevokeApprovalForAll ? (
                               <RevokeApprovalForAll />
                             ) : isReceive(stateChange) ? (

--- a/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/StateChangeSubComponents.tsx
+++ b/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/StateChangeSubComponents.tsx
@@ -49,24 +49,52 @@ export const SetTokenApproval = ({ stateChange }: { stateChange: SimulationState
   );
 };
 
-export const SetApprovalForAll = () => {
+interface SetApprovalForAllProps {
+  verified?: boolean;
+}
+
+export const SetApprovalForAll = (props: SetApprovalForAllProps) => {
   return (
     <div style={{ display: 'flex' }}>
-      <img
-        src="/images/popup/orange-danger.png"
-        alt=""
-        width={33}
-        style={{ alignSelf: 'center', paddingRight: '10px', marginBottom: '10px' }}
-      />
-      <h3
-        style={{ color: '#fb4b4b', fontSize: '16px', marginTop: '4px', paddingBottom: '6px' }}
-        className={`${styles['font-archivo-bold']}`}
-      >
-        {/* todo: make this white if isVerified */}
-        <b>
-          Permission to <br /> withdraw ALL
-        </b>
-      </h3>
+      {props.verified ? (
+        <>
+          <Tooltip
+            hasArrow
+            placement="top"
+            bg="#212121"
+            color="white"
+            className={`${styles['font-archivo-medium']} pl-2 pr-2 pt-1 pb-1`}
+            style={{ borderRadius: '2em' }}
+            label="Marketplaces need this approval to list your asset."
+          >
+            <h3
+              style={{ color: 'white', fontSize: '16px', marginTop: '4px', paddingBottom: '6px' }}
+              className={`${styles['font-archivo-bold']}`}
+            >
+              <b>
+                Permission to <br /> withdraw ALL
+              </b>
+            </h3>
+          </Tooltip>
+        </>
+      ) : (
+        <>
+          <img
+            src="/images/popup/orange-danger.png"
+            alt=""
+            width={33}
+            style={{ alignSelf: 'center', paddingRight: '10px', marginBottom: '10px' }}
+          />
+          <h3
+            style={{ color: '#fb4b4b', fontSize: '16px', marginTop: '4px', paddingBottom: '6px' }}
+            className={`${styles['font-archivo-bold']}`}
+          >
+            <b>
+              Permission to <br /> withdraw ALL
+            </b>
+          </h3>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/StateChangeSubComponents.tsx
+++ b/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/StateChangeSubComponents.tsx
@@ -62,6 +62,7 @@ export const SetApprovalForAll = () => {
         style={{ color: '#fb4b4b', fontSize: '16px', marginTop: '4px', paddingBottom: '6px' }}
         className={`${styles['font-archivo-bold']}`}
       >
+        {/* todo: make this white if isVerified */}
         <b>
           Permission to <br /> withdraw ALL
         </b>

--- a/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/StateChangeSubComponents.tsx
+++ b/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/StateChangeSubComponents.tsx
@@ -58,24 +58,14 @@ export const SetApprovalForAll = (props: SetApprovalForAllProps) => {
     <div style={{ display: 'flex' }}>
       {props.verified ? (
         <>
-          <Tooltip
-            hasArrow
-            placement="top"
-            bg="#212121"
-            color="white"
-            className={`${styles['font-archivo-medium']} pl-2 pr-2 pt-1 pb-1`}
-            style={{ borderRadius: '2em' }}
-            label="Marketplaces need this approval to list your asset."
+          <h3
+            style={{ color: 'white', fontSize: '16px', marginTop: '4px', paddingBottom: '6px' }}
+            className={`${styles['font-archivo-bold']}`}
           >
-            <h3
-              style={{ color: 'white', fontSize: '16px', marginTop: '4px', paddingBottom: '6px' }}
-              className={`${styles['font-archivo-bold']}`}
-            >
-              <b>
-                Permission to <br /> withdraw ALL
-              </b>
-            </h3>
-          </Tooltip>
+            <b>
+              Permission to <br /> withdraw ALL
+            </b>
+          </h3>
         </>
       ) : (
         <>

--- a/src/components/simulation/TransactionContent.tsx
+++ b/src/components/simulation/TransactionContent.tsx
@@ -65,19 +65,35 @@ export const TransactionContent = ({ storedSimulation }: { storedSimulation: Sto
   return (
     <div style={{ marginTop: '-10px' }}>
       {revokeStateChanges.length !== 0 && (
-        <ChangeTypeSection stateChanges={revokeStateChanges} title="You are revoking" />
+        <ChangeTypeSection
+          scanResult={storedSimulation.simulation.scanResult}
+          stateChanges={revokeStateChanges}
+          title="You are revoking"
+        />
       )}
 
       {listingStateChanges.length !== 0 && (
-        <ChangeTypeSection stateChanges={listingStateChanges} title="You are listing" />
+        <ChangeTypeSection
+          scanResult={storedSimulation.simulation.scanResult}
+          stateChanges={listingStateChanges}
+          title="You are listing"
+        />
       )}
 
       {transferAndApproveStateChanges.length !== 0 && (
-        <ChangeTypeSection stateChanges={transferAndApproveStateChanges} title="You are giving" />
+        <ChangeTypeSection
+          scanResult={storedSimulation.simulation.scanResult}
+          stateChanges={transferAndApproveStateChanges}
+          title="You are giving"
+        />
       )}
 
       {receiveStateChanges.length !== 0 && (
-        <ChangeTypeSection stateChanges={receiveStateChanges} title="You are receiving" />
+        <ChangeTypeSection
+          scanResult={storedSimulation.simulation.scanResult}
+          stateChanges={receiveStateChanges}
+          title="You are receiving"
+        />
       )}
     </div>
   );

--- a/src/models/Alert.ts
+++ b/src/models/Alert.ts
@@ -9,6 +9,7 @@ export interface AlertDetail {
   details: string;
   link?: string;
   createdAt: string | number;
+  data?: any;
 }
 
 export enum AlertCategory {


### PR DESCRIPTION
# Added
- [x] Posthog insight for malicious extension detection

# Fixed
- [x] Remove red text and warning symbol for verified websites using Set Approval For All. This made actions like OpenSea listings unnecessarily scary (see below)

### Before
<img width="423" alt="image" src="https://user-images.githubusercontent.com/72634565/229200238-d90b5d8e-6abb-4ec3-8411-b55be4065758.png">


### After
<img width="424" alt="image" src="https://user-images.githubusercontent.com/72634565/229200065-8f3d6e4c-1944-42a5-9774-ce1eabd35e86.png">
