### PR TITLE
Fix: add tabId to phishing detection

### DIFF
--- a/src/services/phishing/phishingService.ts
+++ b/src/services/phishing/phishingService.ts
@@ -30,6 +30,7 @@ export async function checkUrlForPhishing(tab: chrome.tabs.Tab) {
 
       if (recentlyCreatedWarning.level === WarningLevel.Critical) {
         chrome.tabs.update({
+          tabId: tab.id,
           url:
             chrome.runtime.getURL('phish.html') +
             '?safe=' +
@@ -57,6 +58,7 @@ export async function checkUrlForPhishing(tab: chrome.tabs.Tab) {
       const safeURL = similarityWarning?.value || homoglyphWarning?.value || mlWarning?.value || 'null';
       const reason = similarityWarning?.type || homoglyphWarning?.type || mlWarning?.type || blocklistWarning?.type || 'null';
       chrome.tabs.update({
+        tabId: tab.id,
         url:
           chrome.runtime.getURL('phish.html') +
           '?safe=' +

--- a/src/services/phishing/phishingService.ts
+++ b/src/services/phishing/phishingService.ts
@@ -29,8 +29,7 @@ export async function checkUrlForPhishing(tab: chrome.tabs.Tab) {
       const daysSinceCreated = Math.round(parseFloat(recentlyCreatedWarning.value) / 24);
 
       if (recentlyCreatedWarning.level === WarningLevel.Critical) {
-        chrome.tabs.update({
-          tabId: tab.id,
+        chrome.tabs.update(tab.id, {
           url:
             chrome.runtime.getURL('phish.html') +
             '?safe=' +
@@ -57,8 +56,7 @@ export async function checkUrlForPhishing(tab: chrome.tabs.Tab) {
     if (similarityWarning || homoglyphWarning || mlWarning || blocklistWarning) {
       const safeURL = similarityWarning?.value || homoglyphWarning?.value || mlWarning?.value || 'null';
       const reason = similarityWarning?.type || homoglyphWarning?.type || mlWarning?.type || blocklistWarning?.type || 'null';
-      chrome.tabs.update({
-        tabId: tab.id,
+      chrome.tabs.update(tab.id, {
         url:
           chrome.runtime.getURL('phish.html') +
           '?safe=' +

--- a/src/services/phishing/phishingService.ts
+++ b/src/services/phishing/phishingService.ts
@@ -29,7 +29,7 @@ export async function checkUrlForPhishing(tab: chrome.tabs.Tab) {
       const daysSinceCreated = Math.round(parseFloat(recentlyCreatedWarning.value) / 24);
 
       if (recentlyCreatedWarning.level === WarningLevel.Critical) {
-        chrome.tabs.update(tab.id, {
+        chrome.tabs.update(tab.id || chrome.tabs.TAB_ID_NONE, {
           url:
             chrome.runtime.getURL('phish.html') +
             '?safe=' +
@@ -56,7 +56,7 @@ export async function checkUrlForPhishing(tab: chrome.tabs.Tab) {
     if (similarityWarning || homoglyphWarning || mlWarning || blocklistWarning) {
       const safeURL = similarityWarning?.value || homoglyphWarning?.value || mlWarning?.value || 'null';
       const reason = similarityWarning?.type || homoglyphWarning?.type || mlWarning?.type || blocklistWarning?.type || 'null';
-      chrome.tabs.update(tab.id, {
+      chrome.tabs.update(tab.id || chrome.tabs.TAB_ID_NONE, {
         url:
           chrome.runtime.getURL('phish.html') +
           '?safe=' +


### PR DESCRIPTION
Before:
- Going to c0inbase.com and quickly switching tabs updates the new (incorrect) tab

After:
- Going to c0inbase.com and quickly switching tabs updates the correct (c0inbase.com) tab