### PR TITLE
Experiment: Remove onboarding flow for A/B test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eth-rpc-errors": "^4.0.3",
         "parse-domain": "^7.0.0",
         "pino": "^8.8.0",
-        "posthog-js": "^1.40.2",
+        "posthog-js": "^1.53.4",
         "react": "^18.2.0",
         "react-icons": "^4.4.0",
         "react-share": "^4.4.1",
@@ -3438,14 +3438,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.22.0.tgz",
-      "integrity": "sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@sentry/utils": {
       "version": "7.37.1",
@@ -13720,11 +13712,10 @@
       "dev": true
     },
     "node_modules/posthog-js": {
-      "version": "1.40.2",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.40.2.tgz",
-      "integrity": "sha512-jVq/g5J/339u2uHulfpTR57iyG8xmbSKpB9xtbEqp5gQpr/eu0P4OAdfye12tsjm8IB3+7RR/SDArQ7PI/m6Yg==",
+      "version": "1.53.4",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.53.4.tgz",
+      "integrity": "sha512-aaQ9S+/eDuBl2XTuU/lMyMtX7eeNAQ/+53O0O+I05FwX7e5NDN1nVqlnkMP0pfZlFcnsPaVqm8N3HoYj+b7Eow==",
       "dependencies": {
-        "@sentry/types": "7.22.0",
         "fflate": "^0.4.1",
         "rrweb-snapshot": "^1.1.14"
       }
@@ -19423,11 +19414,6 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
-    },
-    "@sentry/types": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.22.0.tgz",
-      "integrity": "sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q=="
     },
     "@sentry/utils": {
       "version": "7.37.1",
@@ -27017,11 +27003,10 @@
       "dev": true
     },
     "posthog-js": {
-      "version": "1.40.2",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.40.2.tgz",
-      "integrity": "sha512-jVq/g5J/339u2uHulfpTR57iyG8xmbSKpB9xtbEqp5gQpr/eu0P4OAdfye12tsjm8IB3+7RR/SDArQ7PI/m6Yg==",
+      "version": "1.53.4",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.53.4.tgz",
+      "integrity": "sha512-aaQ9S+/eDuBl2XTuU/lMyMtX7eeNAQ/+53O0O+I05FwX7e5NDN1nVqlnkMP0pfZlFcnsPaVqm8N3HoYj+b7Eow==",
       "requires": {
-        "@sentry/types": "7.22.0",
         "fflate": "^0.4.1",
         "rrweb-snapshot": "^1.1.14"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eth-rpc-errors": "^4.0.3",
     "parse-domain": "^7.0.0",
     "pino": "^8.8.0",
-    "posthog-js": "^1.40.2",
+    "posthog-js": "^1.53.4",
     "react": "^18.2.0",
     "react-icons": "^4.4.0",
     "react-share": "^4.4.1",

--- a/src/components/app-dashboard/tabs/dashboard/DashboardTab.tsx
+++ b/src/components/app-dashboard/tabs/dashboard/DashboardTab.tsx
@@ -37,7 +37,7 @@ import { OnboardingWelcome } from './onboarding/OnboardingWelcome';
 import { OnboardingSimulation } from './onboarding/OnboardingSimulation';
 import { OnboardingCommunity } from './onboarding/OnboardingCommunity';
 import { OnboardingPhishing } from './onboarding/OnboardingPhishing';
-import { PostHog, posthog } from 'posthog-js';
+import { posthog } from 'posthog-js';
 import { openGuide } from '../../../../lib/helpers/linkHelper';
 
 export function DashboardTab() {

--- a/src/components/app-dashboard/tabs/dashboard/DashboardTab.tsx
+++ b/src/components/app-dashboard/tabs/dashboard/DashboardTab.tsx
@@ -37,7 +37,7 @@ import { OnboardingWelcome } from './onboarding/OnboardingWelcome';
 import { OnboardingSimulation } from './onboarding/OnboardingSimulation';
 import { OnboardingCommunity } from './onboarding/OnboardingCommunity';
 import { OnboardingPhishing } from './onboarding/OnboardingPhishing';
-import { posthog } from 'posthog-js';
+import { PostHog, posthog } from 'posthog-js';
 import { openGuide } from '../../../../lib/helpers/linkHelper';
 
 export function DashboardTab() {
@@ -72,14 +72,25 @@ export function DashboardTab() {
         }
       });
     });
-    localStorageHelpers.get<boolean>(WgKeys.TutorialComplete).then((res) => {
-      if (res !== true) {
-        posthog.capture('startTutorial');
-        setTutorialComplete(false);
-        chrome.storage.local.set({ [WgKeys.TutorialComplete]: true });
-      } else {
+
+    localStorageHelpers.get<boolean>(WgKeys.TutorialComplete).then((tutorialIsComplete) => {
+      if (tutorialIsComplete) {
         setTutorialComplete(true);
+        return;
       }
+
+      chrome.storage.local.set({ [WgKeys.TutorialComplete]: true });
+
+      posthog.onFeatureFlags(() => {
+        const onboardingFeatureEnabled = posthog.getFeatureFlagPayload('show-onboarding') as boolean;
+
+        if (onboardingFeatureEnabled) {
+          posthog.capture('startTutorial');
+          setTutorialComplete(false);
+        } else {
+          setTutorialComplete(true);
+        }
+      });
     });
   }, []);
 


### PR DESCRIPTION
After reviewing Posthog for awhile, I'd like to compare the uninstall rate from users who see the onboarding flow vs users who do not. It might not be a significant difference, but would like to test it regardless to see if this is causing unintended friction.

Here's the insight to test the results: https://app.posthog.com/insights/Iyr7mpZj