### PR TITLE
Fix: version checking bugs

### DIFF
--- a/src/components/app-dashboard/tabs/dashboard/subComponents/ChecklistItem.tsx
+++ b/src/components/app-dashboard/tabs/dashboard/subComponents/ChecklistItem.tsx
@@ -33,6 +33,7 @@ export function ChecklistItem(props: ChecklistItemProps) {
   const { name, localVersion, latestVersion, lastCheckedAt } = props.walletInfo;
   const details: ChecklistDetails = mapInfo();
   const icon = mapIcon(details.icon);
+  const bothVersionsExist = localVersion && latestVersion;
 
   function mapInfo(): ChecklistDetails {
     if (!localVersion) {
@@ -86,15 +87,15 @@ export function ChecklistItem(props: ChecklistItemProps) {
     >
       <img src={`/images/wallets/${name}.png`} height={50} width={50} />
       <div
-        className={`${styles.col} ${localVersion && localVersion !== latestVersion ? styles.hover : ''}`}
+        className={`${styles.col} ${bothVersionsExist && localVersion !== latestVersion ? styles.hover : ''}`}
         style={{ marginLeft: '25px' }}
-        onClick={localVersion && localVersion !== latestVersion ? goToExtensions : () => {}}
+        onClick={bothVersionsExist && localVersion !== latestVersion ? goToExtensions : () => {}}
       >
         <div className={styles.row}>
           <Heading as="h6" fontSize={22}>
             {details.text}
             {icon}
-            {localVersion && localVersion !== latestVersion && (
+            {bothVersionsExist && localVersion !== latestVersion && (
               <Badge className={styles.hover} pl="1" fontSize="13px" colorScheme="yellow" marginLeft={'7px'}>
                 Update
               </Badge>
@@ -102,12 +103,17 @@ export function ChecklistItem(props: ChecklistItemProps) {
           </Heading>
         </div>
         <div className={styles.row}>
-          {localVersion && localVersion !== latestVersion && (
+          {localVersion && !latestVersion && (
+            <Text fontSize={18} color={'gray.300'}>
+              We ran into an issue. Please try again later.
+            </Text>
+          )}
+          {bothVersionsExist && localVersion !== latestVersion && (
             <Text fontSize={18} color={'orange'}>
               Update Now
             </Text>
           )}
-          {localVersion === latestVersion && (
+          {bothVersionsExist && localVersion === latestVersion && (
             <Text fontSize={18} color={'gray.300'}>
               Last Checked: {details.lastCheckedAt}
             </Text>

--- a/src/components/simulation/SimulationSubComponents/BypassButton.tsx
+++ b/src/components/simulation/SimulationSubComponents/BypassButton.tsx
@@ -23,7 +23,7 @@ export const BypassedSimulationButton = ({ storedSimulation }: { storedSimulatio
             <button
               className={`${styles['reject-button']} btn`}
               onClick={() => {
-                posthog.capture('simulation rejected', {
+                posthog.capture('bypassed simulation rejected', {
                   warningType: storedSimulation.simulation?.warningType,
                   storedSimulation: storedSimulation,
                 });

--- a/src/services/http/versionService.ts
+++ b/src/services/http/versionService.ts
@@ -15,9 +15,12 @@ export interface VersionCheckResponse {
 }
 
 async function getVersion(wallet: WalletType): Promise<string | null> {
-  const request: VersionCheckResponse = await (await httpClient.get(`${EDS_URL_PROD}/version/${wallet}`))?.json() || null;
-
-  return request.version;
+  try {
+    const request: VersionCheckResponse = await (await httpClient.get(`${EDS_URL_PROD}/version/${wallet}`))?.json();
+    return request.version;
+  } catch (e) {
+    return null;
+  }
 }
 
 async function checkWallet(wallet: WalletType) {


### PR DESCRIPTION
Fixed some minor bugs related to the version checker when it can't hit the API. For example in the `versionService` on line 20, if we failed to fetch it would result in a null reference exception by trying to return `request.version`. This handles this error gracefully (we had 3k+ cases of this in sentry). 

Also fixed a couple UI bugs by adding better context to when we couldn't reach the API. New text is `We ran into an issue. Please try again later.`. This is a win because previously we would display that the wallet is out of date because we couldn't reach the API, even though the wallet was up-to-date.