### PR TITLE
Better request type safety

### DIFF
--- a/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/TokenInfo.tsx
+++ b/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/TokenInfo.tsx
@@ -47,7 +47,7 @@ export const TokenInfo = (props: StateChangesComponentProps) => {
           bg="#212121"
           color="white"
           placement="right"
-          className={`${styles['font-archivo-bold']}`}
+          className={`${styles['font-archivo-medium']} pl-2 pr-2 pt-1 pb-1`}
           style={{ borderRadius: '2em' }}
         >
           <img src="/images/popup/twitter-verified-badge.svg" alt="" width={25} className="pl-2" />

--- a/src/content-scripts/contentScripts.tsx
+++ b/src/content-scripts/contentScripts.tsx
@@ -41,7 +41,7 @@ listenToRequest(async (request: TransactionArgs) => {
   log.info({ request }, 'Request');
   ids.push(request.id);
 
-  let currentTab = window.location.hostname;
+  let currentTab = window.location.href;
   if (currentTab) {
     request.origin = currentTab;
   }

--- a/src/injected/injectWalletGuard.tsx
+++ b/src/injected/injectWalletGuard.tsx
@@ -21,6 +21,8 @@ export function convertObjectValuesToString(inputObj: any): any {
       }
 
       output[x] = array;
+    } else if (inputObj[x] === null) {
+      output[x] = null;
     } else if (typeof inputObj[x] === 'object') {
       output[x] = convertObjectValuesToString(inputObj[x]);
     } else if (typeof inputObj[x] === 'number' || typeof inputObj[x] === 'bigint') {

--- a/src/injected/injectWalletGuard.tsx
+++ b/src/injected/injectWalletGuard.tsx
@@ -13,7 +13,17 @@ export function convertObjectValuesToString(inputObj: any): any {
   const keys = Object.keys(inputObj);
   const output: any = {};
   for (let x of keys) {
-    if (typeof inputObj[x] === 'number' || typeof inputObj[x] === 'bigint') {
+    if (Array.isArray(inputObj[x])) {
+      const array: any[] = [];
+
+      for (let y in inputObj[x]) {
+        array.push(convertObjectValuesToString(inputObj[x][y]));
+      }
+
+      output[x] = array;
+    } else if (typeof inputObj[x] === 'object') {
+      output[x] = convertObjectValuesToString(inputObj[x]);
+    } else if (typeof inputObj[x] === 'number' || typeof inputObj[x] === 'bigint') {
       output[x] = String(inputObj[x]);
     } else {
       output[x] = inputObj[x];

--- a/src/tests/convertObject.test.ts
+++ b/src/tests/convertObject.test.ts
@@ -1,5 +1,5 @@
-// this function standardizes all values sent to the API into strings to prevent type errors
-export function convertObjectValuesToString(inputObj: any): any {
+// TODO: Make sure this matches what is in injectWalletGuard.tsx. For some reason I can't get tests to run when importing from that file
+function convertObjectValuesToString(inputObj: any): any {
     const keys = Object.keys(inputObj);
     const output: any = {};
     for (let x of keys) {

--- a/src/tests/convertObject.test.ts
+++ b/src/tests/convertObject.test.ts
@@ -28,6 +28,46 @@ function convertObjectValuesToString(inputObj: any): any {
 }
 
 describe('convertObjectValuesToString', () => {
+    it('handles normal transaction', () => {
+        const request = `
+        {
+                "chainId": "0x1",
+                "id": "123",
+                "method": "eth_sendTransaction",
+                "origin": "",
+                "signer": "0x12345",
+                "transaction": {
+                    "data": "0xasdf",
+                    "from": "0x12345",
+                    "gas": "0x91755",
+                    "gasPrice": "0x8sa41",
+                    "to": "0x56789"
+                }
+        }`;
+
+        const expected = `
+        {
+                "chainId": "0x1",
+                "id": "123",
+                "method": "eth_sendTransaction",
+                "origin": "",
+                "signer": "0x12345",
+                "transaction": {
+                    "data": "0xasdf",
+                    "from": "0x12345",
+                    "gas": "0x91755",
+                    "gasPrice": "0x8sa41",
+                    "to": "0x56789"
+                }
+        }`;
+
+        const requestObj = JSON.parse(request);
+        const output = convertObjectValuesToString(requestObj);
+        const expectedObj = JSON.parse(expected);
+
+        expect(expectedObj).toEqual(output);
+    });
+
     it('handles Permit2', () => {
         const badRequest = `{
                 "chainId": "0x1",

--- a/src/tests/convertObject.test.ts
+++ b/src/tests/convertObject.test.ts
@@ -79,7 +79,7 @@ describe('convertObjectValuesToString', () => {
                 "origin": "",
                 "primaryType": "PermitBatch",
                 "signer": "0x12345"
-            }`
+            }`;
 
 
         const testObj = JSON.parse(badRequest);
@@ -89,58 +89,130 @@ describe('convertObjectValuesToString', () => {
         expect(expectedObj).toEqual(output);
     });
 
-    it('handles Permit2', () => {
+    it('handles Seaport OpenComponents', () => {
         const badRequest = `{
-                "chainId": "0x1",
+                "chainId": "0x89",
                 "domain": {
-                    "chainId": "1",
-                    "name": "Permit2",
-                    "verifyingContract": "0xasdf"
+                    "chainId": "137",
+                    "name": "Seaport",
+                    "verifyingContract": "0x00000000000000adc04c56bf30ac9d3c0aaf14dc",
+                    "version": "1.5"
                 },
                 "id": "",
                 "message": {
-                    "details": [
+                    "conduitKey": "0x0000001",
+                    "consideration": [
                         {
-                            "amount": "1461501637330902918203684832716283019655932542975",
-                            "expiration": 1684323541,
-                            "nonce": 0,
-                            "token": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                            "endAmount": "875000000000000000",
+                            "identifierOrCriteria": "0",
+                            "itemType": 0,
+                            "recipient": "0x12345",
+                            "startAmount": "875000000000000000",
+                            "token": "0x0000000000000000000000000000000000000000"
+                        },
+                        {
+                            "endAmount": "100000000000000000",
+                            "identifierOrCriteria": "0",
+                            "itemType": 0,
+                            "recipient": "0x67890",
+                            "startAmount": "100000000000000000",
+                            "token": "0x0000000000000000000000000000000000000000"
+                        },
+                        {
+                            "endAmount": "25000000000000000",
+                            "identifierOrCriteria": "0",
+                            "itemType": 0,
+                            "recipient": "0x00001",
+                            "startAmount": "25000000000000000",
+                            "token": "0x0000000000000000000000000000000000000000"
                         }
                     ],
-                    "sigDeadline": "1684323541",
-                    "spender": "0x98765"
+                    "counter": "0",
+                    "endTime": "1686403247",
+                    "offer": [
+                        {
+                            "endAmount": 1,
+                            "identifierOrCriteria": "1408",
+                            "itemType": 2,
+                            "startAmount": 1,
+                            "token": "0x980341uf093j410"
+                        }
+                    ],
+                    "offerer": "0x12345",
+                    "orderType": "0",
+                    "salt": "5158915845115",
+                    "startTime": "1685798447",
+                    "totalOriginalConsiderationItems": "3",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "method": "eth_signTypedData_v4",
                 "origin": "",
-                "primaryType": "PermitBatch",
+                "primaryType": "OrderComponents",
                 "signer": "0x12345"
             }`;
 
         const expected = `{
-                "chainId": "0x1",
+                "chainId": "0x89",
                 "domain": {
-                    "chainId": "1",
-                    "name": "Permit2",
-                    "verifyingContract": "0xasdf"
+                    "chainId": "137",
+                    "name": "Seaport",
+                    "verifyingContract": "0x00000000000000adc04c56bf30ac9d3c0aaf14dc",
+                    "version": "1.5"
                 },
                 "id": "",
                 "message": {
-                    "details": [
+                    "conduitKey": "0x0000001",
+                    "consideration": [
                         {
-                            "amount": "1461501637330902918203684832716283019655932542975",
-                            "expiration": "1684323541",
-                            "nonce": "0",
-                            "token": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                            "endAmount": "875000000000000000",
+                            "identifierOrCriteria": "0",
+                            "itemType": "0",
+                            "recipient": "0x12345",
+                            "startAmount": "875000000000000000",
+                            "token": "0x0000000000000000000000000000000000000000"
+                        },
+                        {
+                            "endAmount": "100000000000000000",
+                            "identifierOrCriteria": "0",
+                            "itemType": "0",
+                            "recipient": "0x67890",
+                            "startAmount": "100000000000000000",
+                            "token": "0x0000000000000000000000000000000000000000"
+                        },
+                        {
+                            "endAmount": "25000000000000000",
+                            "identifierOrCriteria": "0",
+                            "itemType": "0",
+                            "recipient": "0x00001",
+                            "startAmount": "25000000000000000",
+                            "token": "0x0000000000000000000000000000000000000000"
                         }
                     ],
-                    "sigDeadline": "1684323541",
-                    "spender": "0x98765"
+                    "counter": "0",
+                    "endTime": "1686403247",
+                    "offer": [
+                        {
+                            "endAmount": "1",
+                            "identifierOrCriteria": "1408",
+                            "itemType": "2",
+                            "startAmount": "1",
+                            "token": "0x980341uf093j410"
+                        }
+                    ],
+                    "offerer": "0x12345",
+                    "orderType": "0",
+                    "salt": "5158915845115",
+                    "startTime": "1685798447",
+                    "totalOriginalConsiderationItems": "3",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "method": "eth_signTypedData_v4",
                 "origin": "",
-                "primaryType": "PermitBatch",
+                "primaryType": "OrderComponents",
                 "signer": "0x12345"
-            }`
+            }`;
 
 
         const testObj = JSON.parse(badRequest);

--- a/src/tests/convertObject.test.ts
+++ b/src/tests/convertObject.test.ts
@@ -12,6 +12,9 @@ function convertObjectValuesToString(inputObj: any): any {
 
             output[x] = array;
         }
+        else if (inputObj[x] === null) {
+            output[x] = null;
+        }
         else if (typeof inputObj[x] === 'object') {
             output[x] = convertObjectValuesToString(inputObj[x]);
         } else if (typeof inputObj[x] === 'number' || typeof inputObj[x] === 'bigint') {
@@ -25,6 +28,67 @@ function convertObjectValuesToString(inputObj: any): any {
 }
 
 describe('convertObjectValuesToString', () => {
+    it('handles Permit2', () => {
+        const badRequest = `{
+                "chainId": "0x1",
+                "domain": {
+                    "chainId": "1",
+                    "name": "Permit2",
+                    "verifyingContract": "0xasdf"
+                },
+                "id": "",
+                "message": {
+                    "details": [
+                        {
+                            "amount": "1461501637330902918203684832716283019655932542975",
+                            "expiration": 1684323541,
+                            "nonce": 0,
+                            "token": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                        }
+                    ],
+                    "sigDeadline": "1684323541",
+                    "spender": "0x98765"
+                },
+                "method": "eth_signTypedData_v4",
+                "origin": "",
+                "primaryType": "PermitBatch",
+                "signer": "0x12345"
+            }`;
+
+        const expected = `{
+                "chainId": "0x1",
+                "domain": {
+                    "chainId": "1",
+                    "name": "Permit2",
+                    "verifyingContract": "0xasdf"
+                },
+                "id": "",
+                "message": {
+                    "details": [
+                        {
+                            "amount": "1461501637330902918203684832716283019655932542975",
+                            "expiration": "1684323541",
+                            "nonce": "0",
+                            "token": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                        }
+                    ],
+                    "sigDeadline": "1684323541",
+                    "spender": "0x98765"
+                },
+                "method": "eth_signTypedData_v4",
+                "origin": "",
+                "primaryType": "PermitBatch",
+                "signer": "0x12345"
+            }`
+
+
+        const testObj = JSON.parse(badRequest);
+        const output = convertObjectValuesToString(testObj);
+        const expectedObj = JSON.parse(expected);
+
+        expect(expectedObj).toEqual(output);
+    });
+
     it('handles Permit2', () => {
         const badRequest = `{
                 "chainId": "0x1",

--- a/src/tests/convertObject.test.ts
+++ b/src/tests/convertObject.test.ts
@@ -1,0 +1,88 @@
+// this function standardizes all values sent to the API into strings to prevent type errors
+export function convertObjectValuesToString(inputObj: any): any {
+    const keys = Object.keys(inputObj);
+    const output: any = {};
+    for (let x of keys) {
+        if (Array.isArray(inputObj[x])) {
+            const array: any[] = [];
+
+            for (let y in inputObj[x]) {
+                array.push(convertObjectValuesToString(inputObj[x][y]));
+            }
+
+            output[x] = array;
+        }
+        else if (typeof inputObj[x] === 'object') {
+            output[x] = convertObjectValuesToString(inputObj[x]);
+        } else if (typeof inputObj[x] === 'number' || typeof inputObj[x] === 'bigint') {
+            output[x] = String(inputObj[x]);
+        } else {
+            output[x] = inputObj[x];
+        }
+    }
+
+    return output;
+}
+
+describe('convertObjectValuesToString', () => {
+    it('handles Permit2', () => {
+        const badRequest = `{
+                "chainId": "0x1",
+                "domain": {
+                    "chainId": "1",
+                    "name": "Permit2",
+                    "verifyingContract": "0xasdf"
+                },
+                "id": "",
+                "message": {
+                    "details": [
+                        {
+                            "amount": "1461501637330902918203684832716283019655932542975",
+                            "expiration": 1684323541,
+                            "nonce": 0,
+                            "token": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                        }
+                    ],
+                    "sigDeadline": "1684323541",
+                    "spender": "0x98765"
+                },
+                "method": "eth_signTypedData_v4",
+                "origin": "",
+                "primaryType": "PermitBatch",
+                "signer": "0x12345"
+            }`;
+
+        const expected = `{
+                "chainId": "0x1",
+                "domain": {
+                    "chainId": "1",
+                    "name": "Permit2",
+                    "verifyingContract": "0xasdf"
+                },
+                "id": "",
+                "message": {
+                    "details": [
+                        {
+                            "amount": "1461501637330902918203684832716283019655932542975",
+                            "expiration": "1684323541",
+                            "nonce": "0",
+                            "token": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                        }
+                    ],
+                    "sigDeadline": "1684323541",
+                    "spender": "0x98765"
+                },
+                "method": "eth_signTypedData_v4",
+                "origin": "",
+                "primaryType": "PermitBatch",
+                "signer": "0x12345"
+            }`
+
+
+        const testObj = JSON.parse(badRequest);
+        const output = convertObjectValuesToString(testObj);
+        const expectedObj = JSON.parse(expected);
+
+        expect(expectedObj).toEqual(output);
+    });
+});


### PR DESCRIPTION
- [x] Use href instead of hostname for TAS URLs. This lets us know where txns truly originate
- [x] Add type safety to certain requests which were being malformed
- [x] test this on Rosco's extension tests 