### PR TITLE
add website scan status to unsupported signature

### DIFF
--- a/src/components/simulation/SimulationSubComponents/errors/UnsupportedSignature.tsx
+++ b/src/components/simulation/SimulationSubComponents/errors/UnsupportedSignature.tsx
@@ -139,7 +139,7 @@ function UnsupportedProjectComponent(props: UnsupportedProjectComponentProps) {
                   alt=""
                   width={25}
                   className="pl-2 "
-                  style={{ marginTop: '-14px', alignSelf: 'center' }}
+                  style={{ marginTop: '-15px', alignSelf: 'center' }}
                 />
               </Tooltip>
             )

--- a/src/components/simulation/SimulationSubComponents/errors/UnsupportedSignature.tsx
+++ b/src/components/simulation/SimulationSubComponents/errors/UnsupportedSignature.tsx
@@ -85,7 +85,7 @@ function UnsupportedProjectComponent(props: UnsupportedProjectComponentProps) {
             Website:
           </p>
           <p className={`${styles['font-archivo-medium']}`} style={{ color: 'white' }}>
-            <b>{scanResult?.domainName ? scanResult.domainName : '-'}</b>
+            <b>{scanResult?.domainName ? scanResult.domainName : 'n/a'}</b>
           </p>
           {scanResult?.domainName && scanResult.verified ? (
             <Tooltip

--- a/src/components/simulation/SimulationSubComponents/errors/UnsupportedSignature.tsx
+++ b/src/components/simulation/SimulationSubComponents/errors/UnsupportedSignature.tsx
@@ -5,6 +5,8 @@ import { ErrorComponentProps } from './GeneralError';
 import { SimulationHeader } from '../../SimulationHeader';
 import { ConfirmSimulationButton } from '../../ConfirmSimulationButton';
 import { BypassedSimulationButton } from '../BypassButton';
+import { PhishingResponse, PhishingResult } from '../../../../models/PhishingResponse';
+import { Tooltip } from '@chakra-ui/react';
 
 export default function UnsupportedSignatureComponent(props: ErrorComponentProps) {
   const { currentSimulation } = props;
@@ -23,7 +25,10 @@ export default function UnsupportedSignatureComponent(props: ErrorComponentProps
 
       <div className="row text-center pl-4 pr-4" style={{ justifyContent: 'center' }}>
         {!requestedProject ? (
-          <UnsupportedProjectComponent votedSuccessfullyCB={handleSubmission} />
+          <UnsupportedProjectComponent
+            scanResult={currentSimulation.simulation?.scanResult}
+            votedSuccessfullyCB={handleSubmission}
+          />
         ) : (
           <VotedSuccessfullyComponent />
         )}
@@ -39,10 +44,13 @@ export default function UnsupportedSignatureComponent(props: ErrorComponentProps
 }
 
 interface UnsupportedProjectComponentProps {
+  scanResult?: PhishingResponse;
   votedSuccessfullyCB: () => void;
 }
 
 function UnsupportedProjectComponent(props: UnsupportedProjectComponentProps) {
+  const { scanResult, votedSuccessfullyCB } = props;
+
   return (
     <>
       <div className="row text-center">
@@ -56,7 +64,7 @@ function UnsupportedProjectComponent(props: UnsupportedProjectComponentProps) {
       </div>
 
       <div className="col-12">
-        <h4 className={`${styles['font-archivo-semibold']} pb-3`} style={{ color: 'white', marginBottom: '20px' }}>
+        <h4 className={`${styles['font-archivo-semibold']} pb-1`} style={{ color: 'white', marginBottom: '10px' }}>
           Unsupported Project
         </h4>
       </div>
@@ -66,17 +74,84 @@ function UnsupportedProjectComponent(props: UnsupportedProjectComponentProps) {
           style={{
             color: 'white',
             fontSize: '16px',
+            marginBottom: '10px',
           }}
         >
-          Please make sure you understand this signature before signing it.
+          Please make sure you trust this website before signing it.
         </p>
 
-        <p className={`${styles['font-archivo-medium']}`} style={{ color: '#646464' }}>
+        <div style={{ display: 'flex', flexDirection: 'row', marginBottom: '30px' }}>
+          <p className={`${styles['font-archivo-medium']}`} style={{ color: '#a8a8a8', marginRight: '5px' }}>
+            Website:
+          </p>
+          <p className={`${styles['font-archivo-medium']}`} style={{ color: 'white' }}>
+            <b>{scanResult?.domainName ? scanResult.domainName : '-'}</b>
+          </p>
+          {scanResult?.domainName && scanResult.verified ? (
+            <Tooltip
+              hasArrow
+              label="Verified by Wallet Guard"
+              bg="#212121"
+              color="white"
+              placement="right"
+              className={`${styles['font-archivo-medium']} pl-2 pr-2 pt-1 pb-1`}
+              style={{ borderRadius: '2em' }}
+            >
+              <img
+                src="/images/popup/green-verified.png"
+                alt=""
+                width={25}
+                className="pl-2 "
+                style={{ marginTop: '-15px', alignSelf: 'center' }}
+              />
+            </Tooltip>
+          ) : scanResult?.domainName && scanResult.phishing === PhishingResult.Phishing ? (
+            <Tooltip
+              hasArrow
+              label={'Low Trust Website'}
+              bg="#212121"
+              color="white"
+              placement="right"
+              className={`${styles['font-archivo-medium']} pl-2 pr-2 pt-1 pb-1`}
+              style={{ borderRadius: '2em' }}
+            >
+              <img
+                src="/images/popup/orange-danger.png"
+                alt=""
+                width={25}
+                className="pl-2 "
+                style={{ marginTop: '-15px', alignSelf: 'center' }}
+              />
+            </Tooltip>
+          ) : (
+            scanResult?.domainName && (
+              <Tooltip
+                hasArrow
+                label="This is an unknown website"
+                bg="#212121"
+                color="white"
+                placement="right"
+                className={`${styles['font-archivo-medium']} pl-2 pr-2 pt-1 pb-1`}
+                style={{ borderRadius: '2em' }}
+              >
+                <img
+                  src="/images/popup/unknown.png"
+                  alt=""
+                  width={25}
+                  className="pl-2 "
+                  style={{ marginTop: '-14px', alignSelf: 'center' }}
+                />
+              </Tooltip>
+            )
+          )}
+        </div>
+
+        <p className={`${styles['font-archivo-medium']}`} style={{ color: '#a8a8a8', marginBottom: 0 }}>
           Do you want us to support this project?
         </p>
 
         <div
-          onClick={props.votedSuccessfullyCB}
+          onClick={votedSuccessfullyCB}
           className={styles.hover}
           style={{
             marginTop: '20px',


### PR DESCRIPTION
Slight improvement to the unsupported signature UI - now shows the website's scan result

![image](https://github.com/wallet-guard/wallet-guard-extension/assets/72634565/40c6b245-58b2-423c-a770-e3acd2fe9ea7)
