### PR TITLE
fix theme bugs and improve personal sign args

### DIFF
--- a/src/components/chatweb3/components/Chat/ChatWeb3Tab.tsx
+++ b/src/components/chatweb3/components/Chat/ChatWeb3Tab.tsx
@@ -3,6 +3,8 @@ import { useChat } from '../../../../lib/hooks/useChat';
 import { Chat } from './Chat';
 import { CompletedSuccessfulSimulation } from '../../../../lib/simulation/storage';
 import posthog from 'posthog-js';
+import { ChakraProvider } from '@chakra-ui/react';
+import theme from '../../../../lib/theme';
 
 export const ChatWeb3Tab = ({
   showChatWeb3,
@@ -35,7 +37,7 @@ export const ChatWeb3Tab = ({
   }, []);
 
   return (
-    <>
+    <ChakraProvider theme={theme}>
       {selectedConversation && (
         <div className={`d-flex flex-column text-white`} style={{ fontSize: '0.875rem', height: '100%', minHeight: '100vh' }}>
           <div className="d-flex h-100 w-100">
@@ -57,6 +59,6 @@ export const ChatWeb3Tab = ({
           </div>
         </div>
       )}
-    </>
+    </ChakraProvider>
   );
 };

--- a/src/components/simulation/ReportTransactionModal.tsx
+++ b/src/components/simulation/ReportTransactionModal.tsx
@@ -1,8 +1,9 @@
-import { ChakraProvider, Modal, ModalOverlay, ModalContent, UseDisclosureProps } from '@chakra-ui/react';
+import { ChakraProvider, Modal, ModalOverlay, ModalContent } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import styles from './simulation.module.css';
 import { CompletedSuccessfulSimulation } from '../../lib/simulation/storage';
 import posthog from 'posthog-js';
+import theme from '../../lib/theme';
 
 interface ReportTransactionProps {
   currentSimulation: CompletedSuccessfulSimulation;
@@ -33,10 +34,9 @@ export function ReportTransactionModal(props: ReportTransactionProps) {
   }
 
   return (
-    <ChakraProvider>
+    <ChakraProvider theme={theme}>
       <Modal isCentered closeOnOverlayClick isOpen={isOpen} onClose={onClose}>
         <ModalOverlay backdropFilter="blur(1px)" />
-
         <ModalContent alignItems={'center'}>
           <div style={{ width: '300px', position: 'absolute', top: '-100px', height: '150px', background: '#212121', borderRadius: '8px', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
             <img src='/images/popup/x.png'

--- a/src/components/simulation/SimulationSubComponents/errors/UnsupportedSignature.tsx
+++ b/src/components/simulation/SimulationSubComponents/errors/UnsupportedSignature.tsx
@@ -169,7 +169,7 @@ function VotedSuccessfullyComponent() {
       <div className="row text-center">
         <img
           style={{ marginTop: '75px', marginBottom: '-60px', pointerEvents: 'none' }}
-          src="/images/popup/websiteDetail/green_check.png"
+          src="/images/popup/green_check.png"
           alt="a green checkmark"
         />
       </div>

--- a/src/injected/injectWalletGuard.tsx
+++ b/src/injected/injectWalletGuard.tsx
@@ -10,7 +10,7 @@ declare global {
 
 // Some DApps send these params in reverse
 export function shouldSwapPersonalSignArgs(signer: string, signMessage: string) {
-  return signer.substring(0, 2) !== '0x' && signMessage.substring(0, 2) === '0x';
+  return (signMessage.length === 42 && signer.length !== 42);
 }
 
 // this function standardizes all values sent to the API into strings to prevent type errors

--- a/src/pages/chatweb3.tsx
+++ b/src/pages/chatweb3.tsx
@@ -1,23 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { ChatWeb3Tab } from '../components/chatweb3/components/Chat/ChatWeb3Tab';
-import { ChakraProvider } from '@chakra-ui/react';
-import theme from '../lib/theme';
-
-export const ChatWeb3Page = () => {
-  return (
-    <>
-      <ChatWeb3Tab />
-    </>
-  );
-};
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(
   <React.StrictMode>
-    <ChakraProvider theme={theme}>
-      <ChatWeb3Page />
-    </ChakraProvider>
+    <ChatWeb3Tab />
   </React.StrictMode>
 );

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -11,8 +11,6 @@ import { ErrorComponent } from '../components/simulation/Error';
 import { ChatWeb3Tab } from '../components/chatweb3/components/Chat/ChatWeb3Tab';
 import { BypassedSimulationButton } from '../components/simulation/SimulationSubComponents/BypassButton';
 import { PersonalSign } from '../components/simulation/PersonalSign';
-import { ChakraProvider } from '@chakra-ui/react';
-import theme from '../lib/theme';
 import { TransactionDetails } from '../components/simulation/TransactionDetails';
 import { useSimulation } from '../lib/hooks/useSimulation';
 import { SimulationTabs } from '../components/simulation/SimulationTabs';
@@ -87,13 +85,11 @@ const Popup = () => {
       </div>
 
       {showChatWeb3 ? (
-        <ChakraProvider theme={theme}>
-          <ChatWeb3Tab
-            showChatWeb3={showChatWeb3}
-            setShowChatWeb3={setShowChatWeb3}
-            storedSimulation={successfulSimulation}
-          />
-        </ChakraProvider>
+        <ChatWeb3Tab
+          showChatWeb3={showChatWeb3}
+          setShowChatWeb3={setShowChatWeb3}
+          storedSimulation={successfulSimulation}
+        />
       ) : (
         <>
           <TransactionDetails currentSimulation={successfulSimulation} />


### PR DESCRIPTION
Several bug fixes / improvements:

- [x] Bug fix: invalid image reference after voting for an unsupported signature to be supported
- [x] Bug fix: Added theme prop to `ChakraProvider` inside the transaction details UI. Without this, Chakra would default people to light mode.
- [x] Future proofing: the `shouldSwapPersonalSignArgs` could have resulted in incorrect results. This was initially coded with the assumption that the `signMessage` would already be decoded. However, this may not always be the case. Checking the length of the two strings is a better way to validate this instead of checking for the 0x prefix (and lack thereof)
- [x] Moved initialization of Chakra to inside `ChatWeb3Tab` component, since it was being initialized twice in the two respective parent components