### PR TITLE
fix unknown request arg types equivalency issue

### DIFF
--- a/src/content-scripts/bypassCheck.tsx
+++ b/src/content-scripts/bypassCheck.tsx
@@ -6,6 +6,7 @@ import {
   SimulateRequestArgs,
   Transaction,
   TransactionArgs,
+  UnstandardizedSignatureRequestArgs,
 } from '../models/simulation/Transaction';
 import { uuid4 } from '@sentry/utils';
 import { PortMessage, PortIdentifiers } from '../lib/helpers/chrome/messageHandler';
@@ -84,8 +85,9 @@ window.addEventListener('message', (message) => {
         const contentScriptPort = Browser.runtime.connect({ name: PortIdentifiers.WG_CONTENT_SCRIPT });
         sendMessageToPort(contentScriptPort, request);
       } catch (e) {
-        const request: SignatureRequestArgs = {
-          ...data.params,
+        const request: UnstandardizedSignatureRequestArgs = {
+          signer: 'unknown request type',
+          params: data.params,
           id: uuid4(),
           chainId: String(chainId),
           method: data.method,

--- a/src/injected/injectWalletGuard.tsx
+++ b/src/injected/injectWalletGuard.tsx
@@ -173,7 +173,8 @@ const addWalletGuardProxy = (provider: any) => {
 
           // Request does not conform to EIP-712 - pass along the params
           response = await REQUEST_MANAGER.request({
-            ...request.params,
+            signer: 'unknown request type',
+            params: request.params,
             chainId: await provider.request({ method: 'eth_chainId' }),
             method: request.method,
           });
@@ -368,7 +369,8 @@ const addWalletGuardProxy = (provider: any) => {
             .request({ method: 'eth_chainId' })
             .then((chainId: any) => {
               return REQUEST_MANAGER.request({
-                ...request.params,
+                signer: 'unknown request type',
+                params: request.params,
                 chainId,
                 method: request.method,
               });

--- a/src/lib/helpers/chrome/messageHandler.ts
+++ b/src/lib/helpers/chrome/messageHandler.ts
@@ -46,6 +46,8 @@ export function findApprovedTransaction(approvedTxns: TransactionArgs[], txn: Tr
     return approvedTxns.find((x: any) => x.signMessage === txn.signMessage);
   } else if ('hash' in txn) {
     return approvedTxns.find((x: any) => x.hash === txn.hash);
+  } else if ('params' in txn) {
+    return approvedTxns.find((x: any) => txn.signer === 'unknown request type');
   }
 }
 

--- a/src/lib/simulation/requests.ts
+++ b/src/lib/simulation/requests.ts
@@ -42,7 +42,7 @@ export class RequestManager {
         signMessage: string;
       }
       | {
-        [key: string]: any
+        params: any
       }
     )
   ): Promise<Response> {

--- a/src/models/simulation/Transaction.ts
+++ b/src/models/simulation/Transaction.ts
@@ -32,12 +32,16 @@ export enum SimulationMethodType {
   PersonalSign = 'personal_sign',
 }
 
-export type TransactionArgs = SimulateRequestArgs | SignatureRequestArgs | SignatureHashSignArgs | PersonalSignArgs;
+export type TransactionArgs = SimulateRequestArgs | SignatureRequestArgs | SignatureHashSignArgs | PersonalSignArgs | UnstandardizedSignatureRequestArgs;
 
 // Transaction we want to forward.
 export interface SimulateRequestArgs extends RequestArgs {
   transaction: Transaction;
 };
+
+export interface UnstandardizedSignatureRequestArgs extends RequestArgs {
+  params: any;
+}
 
 export interface SignatureRequestArgs extends RequestArgs {
   // Domain for this signature request.


### PR DESCRIPTION
dumping the request params like such (`...request.params`) is a bad way to type these edge cases. opted to go with `params` instead. also setting signer to this string will also help us to track these a bit better in case of future issues.

the reason for this PR is mainly because I noticed that on the DApp that does this, the bypass check triggers because approvedTransactions doesn't pick it up. reason here: equivalency check never happened since these requests don't conform to the other models