### PR TITLE
revert: skip simulation on verified dapps

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -28,7 +28,6 @@ import { WgKeys } from './lib/helpers/chrome/localStorageKeys';
 import * as Sentry from '@sentry/react';
 import Browser from 'webextension-polyfill';
 import { SUPPORTED_CHAINS } from './lib/config/features';
-import { KNOWN_MARKETPLACES } from './lib/simulation/skip';
 
 const log = logger.child({ component: 'Background' });
 const approvedTxns: TransactionArgs[] = [];
@@ -343,12 +342,12 @@ const contentScriptMessageHandler = async (message: PortMessage, sourcePort: Bro
   const settings = await localStorageHelpers.get<ExtensionSettings>(WgKeys.ExtensionSettings);
   if (!settings?.simulationEnabled) return;
 
-  if ('transaction' in message.data) {
-    const address = message.data.transaction?.to?.toLowerCase();
-    if (KNOWN_MARKETPLACES.includes(address)) {
-      return;
-    }
-  }
+  // if ('transaction' in message.data) {
+  //   const address = message.data.transaction?.to?.toLowerCase();
+  //   if (KNOWN_MARKETPLACES.includes(address)) {
+  //     return;
+  //   }
+  // }
 
   // Check if the transaction was already simulated and confirmed
   const isApproved = findApprovedTransaction(approvedTxns, message.data);

--- a/src/content-scripts/contentScripts.tsx
+++ b/src/content-scripts/contentScripts.tsx
@@ -8,7 +8,6 @@ import type { StoredSimulation } from '../lib/simulation/storage';
 import { removeSimulation, StoredSimulationState } from '../lib/simulation/storage';
 import { TransactionArgs } from '../models/simulation/Transaction';
 import { ExtensionSettings } from '../lib/settings';
-import { IsOfficialMarketplace } from '../lib/simulation/skip';
 
 // Function to inject scripts into browser
 const addScript = (url: string) => {
@@ -47,13 +46,9 @@ listenToRequest(async (request: TransactionArgs) => {
     request.origin = currentTab;
   }
 
-  const isOfficialMarketplace = await IsOfficialMarketplace(request);
-
   // Get User Settings
   localStorageHelpers.get<ExtensionSettings>(WgKeys.ExtensionSettings).then((settings) => {
-    const shouldSkip = settings?.skipOnOfficialMarketplaces && isOfficialMarketplace;
-
-    if (!settings || !settings.simulationEnabled || shouldSkip) {
+    if (!settings || !settings.simulationEnabled) {
       // Immediately respond continue.
       dispatchResponse({
         id: request.id,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -3,7 +3,6 @@ export interface ExtensionSettings {
   simulationEnabled: boolean;
   maliciousExtensionDetection: boolean;
   approvalNotifications: boolean;
-  skipOnOfficialMarketplaces: boolean;
 }
 
 export const WG_EXTENSION_DEFAULT_SETTINGS: ExtensionSettings = {
@@ -11,5 +10,4 @@ export const WG_EXTENSION_DEFAULT_SETTINGS: ExtensionSettings = {
   simulationEnabled: true,
   maliciousExtensionDetection: true,
   approvalNotifications: true,
-  skipOnOfficialMarketplaces: false,
 };


### PR DESCRIPTION
Github would not let me automatically revert #122, therefore I have to remove the references themselves. Some of the PR was useful anyway (such as the Settings Icon and Twitter => X icon change) so I kept those.

Please review #122 side-by-side here to ensure I didn't miss anything.