### PR TITLE
Minor bug fixes in simulator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Wallet Guard: Protect Your Crypto",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Wallet Guard: Protect Your Crypto",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.16",
         "@chakra-ui/react": "^2.5.3",

--- a/src/components/chatweb3/components/Chat/WelcomeModal.tsx
+++ b/src/components/chatweb3/components/Chat/WelcomeModal.tsx
@@ -47,7 +47,7 @@ export const WelcomeModal: React.FC<WelcomeModalProps> = ({ onClose }) => {
     onClose();
 
     if (converted) {
-      openDashboard('simulation_promo', true);
+      openDashboard('simulation_promo');
     }
   }
 

--- a/src/components/common/common.module.css
+++ b/src/components/common/common.module.css
@@ -13,3 +13,13 @@
 .buttonWithIcon:hover {
   background: rgb(20, 20, 20);
 }
+
+.settingsIcon {
+  padding-left: 0.5rem;
+  color: #c4c4c4;
+}
+
+.settingsIcon:hover {
+  color: white;
+  cursor: pointer;
+}

--- a/src/components/simulation/Error.tsx
+++ b/src/components/simulation/Error.tsx
@@ -50,7 +50,7 @@ export const ErrorComponent = (props: ErrorComponentProps) => {
       <SimulationHeader />
 
       <div className="row text-center" style={{ marginTop: '65px' }}>
-        <div className="col-12">
+        <div className="container">
           <img
             src="/images/popup/simulation_error.png"
             alt="A picture of a wallet UI with a red exclamation mark displayed in the center of the screen over an empty transaction screen representing an error"

--- a/src/components/simulation/Error.tsx
+++ b/src/components/simulation/Error.tsx
@@ -49,12 +49,12 @@ export const ErrorComponent = (props: ErrorComponentProps) => {
     <div>
       <SimulationHeader />
 
-      <div className="row text-center" style={{ marginTop: '65px' }}>
-        <div className="container">
+      <div className="container" style={{ marginTop: '65px' }}>
+        <div className='flex row justify-content-center'>
           <img
             src="/images/popup/simulation_error.png"
             alt="A picture of a wallet UI with a red exclamation mark displayed in the center of the screen over an empty transaction screen representing an error"
-            width={150}
+            width={'150px'}
           />
         </div>
       </div>

--- a/src/components/simulation/SimulationHeader.tsx
+++ b/src/components/simulation/SimulationHeader.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { RecommendedActionType } from '../../models/simulation/Transaction';
 import { NavbarShareButton } from '../common/NavbarShareButton';
 import { CiSettings } from 'react-icons/ci';
+import { openDashboard } from '../../lib/helpers/linkHelper';
+import styles from '../common/common.module.css';
 
 interface SimulationHeaderProps {
   // Details are all or nothing
@@ -57,9 +59,11 @@ export const SimulationHeader: React.FC<SimulationHeaderProps> = ({ details }) =
         <div style={{ display: 'flex', float: 'right', fontFamily: 'ArchivoBold' }}>
           {/* <NavbarNotifications /> */}
           <NavbarShareButton />
-          <a href="https://dashboard.walletguard.app/settings/extension" target="_blank" rel="noreferrer">
-            <CiSettings size={34} className="pl-2 text-white hover:text-white transform hover:scale-110" />
-          </a>
+
+          <CiSettings
+            onClick={() => openDashboard('settings')}
+            size={34}
+            className={styles['settingsIcon']} />
         </div>
       </div>
     </div>

--- a/src/components/simulation/SimulationSubComponents/errors/RevertError.tsx
+++ b/src/components/simulation/SimulationSubComponents/errors/RevertError.tsx
@@ -20,7 +20,7 @@ export default function RevertComponent(props: ErrorComponentProps) {
             marginBottom: 0,
           }}
         >
-          This can occur when a transaction is no longer valid.
+          This transaction may no longer be valid.
         </p>
 
         <p

--- a/src/components/simulation/SimulationSubComponents/errors/RevertError.tsx
+++ b/src/components/simulation/SimulationSubComponents/errors/RevertError.tsx
@@ -1,17 +1,50 @@
 import React from 'react';
 import styles from '../../simulation.module.css';
-import ErrorTextComponent from './ErrorText';
 import { ErrorComponentProps } from './GeneralError';
 
 export default function RevertComponent(props: ErrorComponentProps) {
   return (
-    <div className="row pt-5 text-center pl-4 pr-4">
+    <div className="pt-5 text-center">
       <div className="col-12">
-        <h4 className={`${styles['font-archivo-semibold']} pb-3`} style={{ color: 'white', marginBottom: '20px' }}>
-          The transaction will be reverted
+        <h4 className={`${styles['font-archivo-semibold']} pb-3`} style={{ color: 'white' }}>
+          This transaction may fail
         </h4>
       </div>
-      <ErrorTextComponent currentSimulation={props.currentSimulation} />
+
+      <div className="container text-center">
+        <p
+          className={`${styles['font-archivo-medium']}`}
+          style={{
+            color: 'white',
+            fontSize: '16px',
+            marginBottom: 0,
+          }}
+        >
+          This can occur when a transaction is no longer valid.
+        </p>
+
+        <p
+          className={`${styles['font-archivo-medium']}`}
+          style={{
+            color: 'white',
+            fontSize: '16px',
+            marginBottom: 0,
+            marginTop: '10px'
+          }}
+        >
+          For example: if you try to buy an NFT but it's already been sold, the transaction will fail and you will lose your gas fee.
+        </p>
+
+        <p
+          className={`${styles['font-archivo-medium']} text-muted`}
+          style={{
+            fontSize: '16px',
+            marginTop: '10px'
+          }}
+        >
+          ID: {props.currentSimulation.id}
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/lib/helpers/linkHelper.ts
+++ b/src/lib/helpers/linkHelper.ts
@@ -4,18 +4,11 @@ export function openGuide() {
   });
 }
 
-export function openDashboard(source: string, isSimulator = false) {
-  if (isSimulator) {
-    chrome.tabs.create({
-      url: 'https://dashboard.walletguard.app/?client=extension&source=' + source
-    });
-    return;
-  }
-
-  if (source === 'install') {
+export function openDashboard(source: string) {
+  if (source === 'settings') {
+    chrome.tabs.create({ url: 'https://dashboard.walletguard.app/settings/extension/?client=extension&source=settings' });
+  } else if (source === 'install') {
     chrome.tabs.create({ url: 'https://dashboard.walletguard.app/onboarding/welcome/?client=extension&source=install' });
-  } else if (source === 'phishing_page_my_dashboard') {
-    chrome.tabs.update({ url: 'https://dashboard.walletguard.app/?client=extension&source=' + source });
   } else {
     chrome.tabs.create({ url: 'https://dashboard.walletguard.app/?client=extension&source=' + source });
   }


### PR DESCRIPTION
Some quick improvements
- Revert error screen text has improved clarity
- Centering was weird on the error screen, causing some overflow that is now fixed
- the tailwind effects on the settings icon was not working, so I converted it to a class
- cleaned up `openDashboard()` function implementation

NEW wording:
![image](https://github.com/wallet-guard/wallet-guard-extension/assets/72634565/8353ff78-e7b6-4f6d-a189-156ca29044cd)
