### PR TITLE
Fix: add header to loading state

### DIFF
--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -5,7 +5,7 @@ import { ConfirmSimulationButton } from '../components/simulation/SimulationButt
 import { NoSimulation } from '../components/simulation/NoSimulation';
 import { SimulationHeader } from '../components/simulation/SimulationHeader';
 import { TransactionContent } from '../components/simulation/TransactionContent';
-import { SimulationMethodType } from '../models/simulation/Transaction';
+import { RecommendedActionType, SimulationMethodType } from '../models/simulation/Transaction';
 import * as Sentry from '@sentry/react';
 import { ErrorComponent } from '../components/simulation/Error';
 import { ChatWeb3Tab } from '../components/chatweb3/components/Chat/ChatWeb3Tab';
@@ -53,6 +53,7 @@ const Popup = () => {
   if (currentSimulation.state === StoredSimulationState.Simulating) {
     return (
       <>
+        <SimulationHeader details={{ recommendedAction: RecommendedActionType.None, verified: false }} />
         <SimulationLoading />;
         <ConfirmSimulationButton storedSimulation={currentSimulation} />
       </>


### PR DESCRIPTION
Quick win to make the simulation loading more consistent with the rest of the UI layout

### Before
![image](https://github.com/wallet-guard/wallet-guard-extension/assets/72634565/c7c23570-09ee-4f2c-821d-99b11571c00e)

### After
![image](https://github.com/wallet-guard/wallet-guard-extension/assets/72634565/c1ca3aaa-83f6-41c1-979e-4166ed1ddbd5)
