### PR TITLE
fix symbol mapping logic

### DIFF
--- a/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/StateChangeSubComponents.tsx
+++ b/src/components/simulation/SimulationSubComponents/stateChangeSubComponents/StateChangeSubComponents.tsx
@@ -57,7 +57,7 @@ export const ApprovalChange = (props: ApprovalProps) => {
         style={{ color: verified ? 'white' : '#fb4b4b', fontSize: '18px', marginBottom: 0 }}
         className={`${styles['font-archivo-bold']}`}
       >
-        {roundedAmount} {symbol || isNFT ? 'NFT' : 'tokens'}
+        {roundedAmount} {symbol || (isNFT ? 'NFT' : 'tokens')}
       </h3>
 
       {roundedAmount !== 'ALL' && (


### PR DESCRIPTION
Javascript_is_fun.exe 🙃 

<img width="407" alt="image" src="https://github.com/wallet-guard/wallet-guard-extension/assets/72634565/34ba8c3a-67a0-426f-91a2-22669c149339">

the issue is that all symbols were always falling back to either `NFT` or `tokens` here instead of their respective symbol
